### PR TITLE
해시태그 검색 구현

### DIFF
--- a/src/main/java/com/spring/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/spring/projectboard/controller/ArticleController.java
@@ -61,4 +61,21 @@ public class ArticleController {
         model.addAttribute("totalCount", articleService.getArticleCount());
         return "articles/detail";
     }
+
+    @GetMapping("/search-hashtag")
+    public String searchHashtag(
+            @RequestParam(required = false) String searchValue,
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            Model model) {
+        Page<ArticleResponse> articles = articleService.searchArticlesViaHashtag(searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+        List<String> hashtags = articleService.getHashtags();
+
+        model.addAttribute("articles", articles);
+        model.addAttribute("hashtags", hashtags);
+        model.addAttribute("paginationBarNumbers", barNumbers);
+        model.addAttribute("searchType", SearchType.HASHTAG);
+
+        return "articles/search-hashtag";
+    }
 }

--- a/src/main/java/com/spring/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/spring/projectboard/repository/ArticleRepository.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.spring.projectboard.domain.Article;
 import com.spring.projectboard.domain.QArticle;
+import com.spring.projectboard.repository.querydsl.ArticleRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
+        ArticleRepositoryCustom,
         QuerydslPredicateExecutor<Article>,
         QuerydslBinderCustomizer<QArticle> {
     @Override

--- a/src/main/java/com/spring/projectboard/repository/querydsl/ArticleRepositoryCustom.java
+++ b/src/main/java/com/spring/projectboard/repository/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.spring.projectboard.repository.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+    List<String> findAllDistinctHashtags();
+}

--- a/src/main/java/com/spring/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/spring/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,24 @@
+package com.spring.projectboard.repository.querydsl;
+
+import com.querydsl.jpa.JPQLQuery;
+import com.spring.projectboard.domain.Article;
+import com.spring.projectboard.domain.QArticle;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom {
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    @Override
+    public List<String> findAllDistinctHashtags() {
+        QArticle article = QArticle.article;
+        JPQLQuery<String> query = from(article)
+                .distinct()
+                .select(article.hashtag)
+                .where(article.hashtag.isNotNull());
+        return query.fetch();
+    }
+}

--- a/src/main/java/com/spring/projectboard/service/ArticleService.java
+++ b/src/main/java/com/spring/projectboard/service/ArticleService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityNotFoundException;
+import java.util.List;
 
 @Slf4j
 @Transactional
@@ -65,5 +66,17 @@ public class ArticleService {
 
     public long getArticleCount() {
         return articleRepository.count();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
+        if (hashtag == null || hashtag.isBlank()) {
+            return Page.empty(pageable);
+        }
+        return articleRepository.findByHashtag(hashtag, pageable).map(ArticleDto::from);
+    }
+
+    public List<String> getHashtags() {
+        return articleRepository.findAllDistinctHashtags();
     }
 }

--- a/src/main/resources/templates/articles/search-hashtag.html
+++ b/src/main/resources/templates/articles/search-hashtag.html
@@ -2,9 +2,74 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Articles</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="Joo">
+    <title>해시태그 검색</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-9ndCyUaIbzAi2FUVXJi0CjmCapSmO7SnpJef0486qhLnuZ2cdeRhO02iuK6FUUVM" crossorigin="anonymous">
+    <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
 <body>
-게시글 해시태그 검색
+- 게시글 해시태그 검색
+    <header id="header">
+        헤더 삽입부
+        <hr>
+    </header>
+
+    <main>
+        <header class="py-5 text-center">
+            <h1>Hashtags</h1>
+        </header>
+
+        <section class="row">
+            <div id="hashtags" class="col-9 d-flex flex-wrap justify-content-evenly">
+                <div class="p-2">
+                    <h2 class="text-center lh-lg font-monospace"><a href="#">#java</a></h2>
+                </div>
+            </div>
+        </section>
+
+        <hr>
+
+        <table class="table" id="article-table">
+            <thead>
+            <tr>
+                <th class="title col-6"><a>제목</a></th>
+                <th class="content col-4"><a>본문</a></th>
+                <th class="user-id"><a>작성자</a></th>
+                <th class="created-at"><a>작성일</a></th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <td class="title"><a>첫글</a></td>
+                <td class="content"><span class="d-inline-block text-truncate" style="max-width: 300px;">본문</span></td>
+                <td class="nickname">Joo</td>
+                <td class="created-at"><time>2022-01-01</time></td>
+            </tr>
+            <tr>
+                <td>두번째글</td>
+                <td>본문</td>
+                <td>Joo</td>
+                <td><time>2022-01-02</time></td>
+            </tr>
+            <tr>
+                <td>세번째글</td>
+                <td>본문</td>
+                <td>Joo</td>
+                <td><time>2022-01-03</time></td>
+            </tr>
+            </tbody>
+        </table>
+
+        <nav aria-label="Page navigation" id="pagination">
+            <ul class="pagination justify-content-center">
+                <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+                <li class="page-item"><a class="page-link" href="#">1</a></li>
+                <li class="page-item"><a class="page-link" href="#">Next</a></li>
+            </ul>
+        </nav>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js" integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz" crossorigin="anonymous"></script>
 </body>
 </html>

--- a/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thlogic>
+    <attr sel="#header" th:replace="header :: header"></attr>
+    <attr sel="#footer" th:replace="footer :: footer"></attr>
+
+    <attr sel="main" th:object="${articles}">
+        <attr sel="#hashtags" th:remove="all-but-first">
+            <attr sel="div" th:each="hashtag : ${hashtags}">
+                <attr sel="a" th:class="'text-reset'" th:text="${hashtag}" th:href="@{/articles/search-hashtag(
+                    page=${param.page},
+                    sort=${param.sort},
+                    searchType=${searchType.name},
+                    searchValue=${hashtag})}"/>
+            </attr>
+        </attr>
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a"
+                      th:text="'제목'"
+                      th:href="@{/articles(page=${articles.number}, sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''), searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                />
+                <attr sel="th.content/a"
+                      th:text="'본문'"
+                      th:href="@{/articles(page=${articles.number}, sort='content' + (*{sort.getOrderFor('content')} != null ? (*{sort.getOrderFor('content').direction.name} != 'DESC' ? ',desc' : '') : ''), searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                />
+                <attr sel="th.user-id/a"
+                      th:text="'작성자'"
+                      th:href="@{/articles(page=${articles.number}, sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''), searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                />
+                <attr sel="th.created-at/a"
+                      th:text="'작성일'"
+                      th:href="@{/articles(page=${articles.number}, sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''), searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                />
+            </attr>
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.content/span" th:text="${article.content}" />
+                    <attr sel="td.nickname" th:text="${article.nickname}" />
+                    <attr sel="td.created-at" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+                </attr>
+            </attr>
+        </attr>
+        <attr sel="#pagination">
+            <attr sel="li[0]/a"
+                  th:text="'Previous'"
+                  th:href="@{/articles(page=${articles.number - 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                  th:class="'page-link' + (${articles.number} <= 0 ? ' disalbes' : '')"
+            />
+            <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                <attr sel="a"
+                      th:text="${pageNumber + 1}"
+                      th:href="@{/articles(page=${pageNumber}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                />
+            </attr>
+            <attr sel="li[2]/a"
+                  th:text="'Next'"
+                  th:href="@{/articles(page=${articles.number + 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                  th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disalbes' : '')"
+            />
+        </attr>
+    </attr>
+
+
+</thlogic>

--- a/src/test/java/com/spring/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/spring/projectboard/service/ArticleServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Pageable;
 
 import javax.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -55,6 +56,46 @@ class ArticleServiceTest {
         // Then
         assertThat(articles).isEmpty();
         then(articleRepository).should().findAll(pageable);
+    }
+
+    @DisplayName("해시태그 검색하여 게시글 페이지 반환")
+    @Test
+    void searchArticlesWithHashtag() {
+        // Given
+        String hashtag = "#java";
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findByHashtag(hashtag, pageable)).willReturn(Page.empty(pageable));
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(hashtag, pageable);
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).should().findByHashtag(hashtag, pageable);
+    }
+
+    @DisplayName("검색어 없이 해시태그 검색하여 게시글 페이지 반환")
+    @Test
+    void noSearchArticlesWithHashtag() {
+        // Given
+        Pageable pageable = Pageable.ofSize(20);
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(null, pageable);
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("해시태그 리스트 조회")
+    @Test
+    void getHashtags(){
+        // Given
+        List<String> expectedHashtags = List.of("#java", "#spring", "#boot");
+        given(articleRepository.findAllDistinctHashtags()).willReturn(expectedHashtags);
+        // When
+        List<String> actualHashtags = sut.getHashtags();
+        // Then
+        assertThat(actualHashtags).isEqualTo(expectedHashtags);
+        then(articleRepository).should().findAllDistinctHashtags();
     }
 
     @DisplayName("ID로 게시글 조회")


### PR DESCRIPTION
- 추가 기능 구현
    - unique한 해시태그들을 추출하기 위해 querydsl을 사용하여 쿼리를 작성
    - 서비스, 컨트롤러 업데이트 
- 해시태그 페이지 구현
    - 모든 해시태그들의 리스트를 나타냄
    - 처음 호출된 페이지는 검색 결과 테이블이 비어있음
    - 검색 결과 테이블은 게시판 페이지와 동일한 형태
    - 테이블에 해시태그를 빼고 본문을 추가하여 본문의 일부를 잘라서 보여줌
- 테스트