### PR TITLE
게시글 댓글 구현

### DIFF
--- a/src/main/java/com/spring/projectboard/controller/ArticleCommentController.java
+++ b/src/main/java/com/spring/projectboard/controller/ArticleCommentController.java
@@ -1,0 +1,31 @@
+package com.spring.projectboard.controller;
+
+import com.spring.projectboard.dto.UserAccountDto;
+import com.spring.projectboard.request.ArticleCommentRequest;
+import com.spring.projectboard.request.ArticleRequest;
+import com.spring.projectboard.service.ArticleCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping("/comments")
+@Controller
+public class ArticleCommentController {
+    private final ArticleCommentService articleCommentService;
+
+    @PostMapping("/new")
+    public String postNewComment(ArticleCommentRequest articleCommentRequest) {
+        // TODO: 인증 정보 추가
+        articleCommentService.saveComment(articleCommentRequest.toDto(UserAccountDto.of("joo", "pw", "joo@gamil.com", "joo", "memo")));
+        return "redirect:/articles/" + articleCommentRequest.articleId();
+    }
+
+    @PostMapping("{commentId}/delete")
+    public String deleteComment(@PathVariable Long commentId, Long articleId) {
+        articleCommentService.deleteComment(commentId);
+        return "redirect:/articles/" + articleId;
+    }
+}

--- a/src/main/java/com/spring/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/spring/projectboard/controller/ArticleController.java
@@ -30,7 +30,7 @@ import java.util.List;
  * /articles/search-hashtag
  */
 @RequiredArgsConstructor
-@RequestMapping("articles")
+@RequestMapping("/articles")
 @Controller
 public class ArticleController {
     private final ArticleService articleService;

--- a/src/main/java/com/spring/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/spring/projectboard/controller/ArticleController.java
@@ -96,11 +96,7 @@ public class ArticleController {
                                 "pw",
                                 "joo@gmail.com",
                                 "Joo",
-                                "memo",
-                                null,
-                                null,
-                                null,
-                                null)
+                                "memo")
                 )
         );
         return "redirect:/articles";
@@ -127,11 +123,7 @@ public class ArticleController {
                                 "pw",
                                 "joo@gmail.com",
                                 "Joo",
-                                "memo",
-                                null,
-                                null,
-                                null,
-                                null)
+                                "memo")
                 )
         );
         return "redirect:/articles/" + articleId;

--- a/src/main/java/com/spring/projectboard/dto/ArticleCommentDto.java
+++ b/src/main/java/com/spring/projectboard/dto/ArticleCommentDto.java
@@ -2,6 +2,7 @@ package com.spring.projectboard.dto;
 
 import com.spring.projectboard.domain.Article;
 import com.spring.projectboard.domain.ArticleComment;
+import com.spring.projectboard.domain.UserAccount;
 
 import java.time.LocalDateTime;
 
@@ -19,6 +20,10 @@ public record ArticleCommentDto(
         return new ArticleCommentDto(id, articleId, userAccountDto, content, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
+    public static ArticleCommentDto of(Long articleId, UserAccountDto userAccountDto, String content) {
+        return new ArticleCommentDto(null, articleId, userAccountDto, content, null, null, null, null);
+    }
+
     public static ArticleCommentDto from(ArticleComment articleComment) {
         return new ArticleCommentDto(
                 articleComment.getId(),
@@ -32,9 +37,9 @@ public record ArticleCommentDto(
         );
     }
 
-    public ArticleComment toEntity(Article article) {
+    public ArticleComment toEntity(Article article, UserAccount userAccount) {
         return ArticleComment.of(
-                userAccountDto.toEntity(),
+                userAccount,
                 article,
                 content
         );

--- a/src/main/java/com/spring/projectboard/dto/UserAccountDto.java
+++ b/src/main/java/com/spring/projectboard/dto/UserAccountDto.java
@@ -19,6 +19,10 @@ public record UserAccountDto(
         return new UserAccountDto(userId, userPassword, email, nickname, memo, createdAt, createdBy, modifiedAt, modifiedBy);
     }
 
+    public static UserAccountDto of(String userId, String userPassword,String email, String nickname, String memo) {
+        return new UserAccountDto(userId, userPassword, email, nickname, memo, null, null, null, null);
+    }
+
     public static UserAccountDto from(UserAccount userAccount) {
         return new UserAccountDto(
                 userAccount.getUserId(),

--- a/src/main/java/com/spring/projectboard/request/ArticleCommentRequest.java
+++ b/src/main/java/com/spring/projectboard/request/ArticleCommentRequest.java
@@ -1,0 +1,21 @@
+package com.spring.projectboard.request;
+
+import com.spring.projectboard.dto.ArticleCommentDto;
+import com.spring.projectboard.dto.UserAccountDto;
+
+public record ArticleCommentRequest(
+        Long articleId,
+        String content
+) {
+    public static ArticleCommentRequest of(Long articleId, String content) {
+        return new ArticleCommentRequest(articleId, content);
+    }
+
+    public ArticleCommentDto toDto(UserAccountDto userAccountDto) {
+        return ArticleCommentDto.of(
+                articleId,
+                userAccountDto,
+                content
+        );
+    }
+}

--- a/src/main/java/com/spring/projectboard/service/ArticleCommentService.java
+++ b/src/main/java/com/spring/projectboard/service/ArticleCommentService.java
@@ -1,9 +1,12 @@
 package com.spring.projectboard.service;
 
+import com.spring.projectboard.domain.Article;
 import com.spring.projectboard.domain.ArticleComment;
+import com.spring.projectboard.domain.UserAccount;
 import com.spring.projectboard.dto.ArticleCommentDto;
 import com.spring.projectboard.repository.ArticleCommentRepository;
 import com.spring.projectboard.repository.ArticleRepository;
+import com.spring.projectboard.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,8 +20,9 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class ArticleCommentService {
-    private final ArticleCommentRepository articleCommentRepository;
+    private final UserAccountRepository userAccountRepository;
     private final ArticleRepository articleRepository;
+    private final ArticleCommentRepository articleCommentRepository;
 
     @Transactional(readOnly = true)
     public List<ArticleCommentDto> getComments(Long articleId) {
@@ -30,9 +34,11 @@ public class ArticleCommentService {
 
     public void saveComment(ArticleCommentDto dto) {
         try{
-            articleCommentRepository.save(dto.toEntity(articleRepository.getReferenceById(dto.articleId())));
+            Article article = articleRepository.getReferenceById(dto.articleId());
+            UserAccount userAccount = userAccountRepository.getReferenceById(dto.userAccountDto().userId());
+            articleCommentRepository.save(dto.toEntity(article, userAccount));
         } catch (EntityNotFoundException e) {
-            log.warn("댓글 저장 실패! 게시글을 찾을 수 없습니다. - dto: {}", dto);
+            log.warn("댓글 저장 실패! 댓글 작성에 필요한 정보를 찾을 수 없습니다. - {}", e);
         }
     }
 

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -44,10 +44,11 @@
 
     <div class="row g-5">
       <section>
-        <form class="row g-3">
+        <form class="row g-3" id="comment-form">
+          <input type="hidden" class="article-id">
           <div class="col-md-9 col-lg-8">
             <label for="comment-textbox" hidden>댓글</label>
-            <textarea class="form-control" id="comment-textbox" placeholder="댓글 쓰기.." rows="3"></textarea>
+            <textarea class="form-control" id="comment-textbox" placeholder="댓글 쓰기.." rows="3" required></textarea>
           </div>
           <div class="col-md-3 col-lg-4">
             <label for="comment-submit" hidden>댓글 쓰기</label>
@@ -56,17 +57,25 @@
         </form>
         <ul id="article-comments" class="row col-md-10 col-lg-8 pt-3">
           <li>
-            <div class="row">
-              <strong>Anonymous1</strong>
-              <small><time>2022-01-01</time></small>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
-                Lorem ipsum dolor sit amet
-              </p>
-            </div>
+            <form class="comment-form">
+              <input type="hidden" class="article-id">
+              <div class="row">
+                <div class="col-md-10 col-lg-9">
+                  <strong>Anonymous1</strong>
+                  <small><time>2022-01-01</time></small>
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
+                    Lorem ipsum dolor sit amet
+                  </p>
+                </div>
+                <div class="col-2 mb-3">
+                  <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
+                </div>
+              </div>
+            </form>
           </li>
           <li>
-            <div class="row">
+            <div>
               <strong>Anonymous2</strong>
               <small><time>2022-01-01</time></small>
               <p>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -18,11 +18,17 @@
             </attr>
         </attr>
         <!--댓글-->
+        <attr sel=".article-id" th:name="articleId" th:value="*{id}" />
+        <attr sel="#comment-form" th:action="@{/comments/new}" th:method="post">
+            <attr sel="#comment-textbox" th:name="content" />
+        </attr>
         <attr sel="#article-comments" th:remove="all-but-first">
             <attr sel="li[0]" th:each="articleComment : ${articleComments}">
-                <attr sel="div/strong" th:text="${articleComment.nickname}" />
-                <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
-                <attr sel="div/p" th:text="${articleComment.content}" />
+                <attr sel="form" th:action="'/comments/' + ${articleComment.id} + '/delete'" th:method="post">
+                    <attr sel="div/strong" th:text="${articleComment.nickname}" />
+                    <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
+                    <attr sel="div/p" th:text="${articleComment.content}" />
+                </attr>
             </attr>
         </attr>
         <!--페이지네이션-->

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -9,7 +9,8 @@
     <div class="container">
         <div class="d-flex flex-wrap align-items-center justify-content-center justify-content-lg-start">
             <ul class="nav col-12 col-lg-auto me-lg-auto mb-2 justify-content-center mb-md-0">
-                <li><a href="/" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="home" href="#" class="nav-link px-2 text-secondary">Home</a></li>
+                <li><a id="hashtag" href="#" class="nav-link px-2 text-secondary">Hashtags</a></li>
             </ul>
 
             <div class="text-end">

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<thlogic>
+    <attr sel="#home" th:href="@{/}" />
+    <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+</thlogic>

--- a/src/test/java/com/spring/projectboard/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/spring/projectboard/controller/ArticleCommentControllerTest.java
@@ -1,0 +1,84 @@
+package com.spring.projectboard.controller;
+
+import com.spring.projectboard.config.SecurityConfig;
+import com.spring.projectboard.dto.ArticleCommentDto;
+import com.spring.projectboard.dto.ArticleDto;
+import com.spring.projectboard.request.ArticleCommentRequest;
+import com.spring.projectboard.request.ArticleRequest;
+import com.spring.projectboard.service.ArticleCommentService;
+import com.spring.projectboard.service.ArticleService;
+import com.spring.projectboard.service.PaginationService;
+import com.spring.projectboard.util.FormDataEncoder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 댓글")
+@Import({SecurityConfig.class, FormDataEncoder.class})
+@WebMvcTest(ArticleCommentController.class)
+class ArticleCommentControllerTest {
+    private final MockMvc mvc;
+    private final FormDataEncoder formDataEncoder;
+
+    @MockBean private ArticleCommentService articleCommentService;
+
+    public ArticleCommentControllerTest(@Autowired MockMvc mvc, @Autowired FormDataEncoder formDataEncoder) {
+        this.mvc = mvc;
+        this.formDataEncoder = formDataEncoder;
+    }
+
+    @DisplayName("[view][POST] 댓글 등록 - 정상 호출")
+    @Test
+    void saveNewComment() throws Exception {
+        // Given
+        long articleId = 1L;
+        ArticleCommentRequest request = ArticleCommentRequest.of(articleId, "test comment");
+        willDoNothing().given(articleCommentService).saveComment(any(ArticleCommentDto.class));
+        // When & Then
+        mvc.perform(
+                        post("/comments/new")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .content(formDataEncoder.encode(request))
+                                .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles/" + articleId))
+                .andExpect(redirectedUrl("/articles/" + articleId));
+        then(articleCommentService).should().saveComment(any(ArticleCommentDto.class));
+    }
+
+    @DisplayName("[view][POST] 댓글 삭제 - 정상 호출")
+    @Test
+    void deleteComment() throws Exception {
+        // Given
+        long articleId = 1L;
+        long articleCommentId = 1L;
+        willDoNothing().given(articleCommentService).deleteComment(articleCommentId);
+        // When & Then
+        mvc.perform(
+                        post("/comments/" + articleCommentId + "/delete")
+                                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                                .content(formDataEncoder.encode(Map.of("articleId", articleId)))
+                                .with(csrf())
+                )
+                .andExpect(status().is3xxRedirection())
+                .andExpect(view().name("redirect:/articles/" + articleId))
+                .andExpect(redirectedUrl("/articles/" + articleId));
+        then(articleCommentService).should().deleteComment(articleCommentId);
+    }
+}

--- a/src/test/java/com/spring/projectboard/controller/ArticleControllerTest.java
+++ b/src/test/java/com/spring/projectboard/controller/ArticleControllerTest.java
@@ -121,7 +121,7 @@ class ArticleControllerTest {
         then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
-    @DisplayName("[view] [GET] 게시글 페이지- 정상 호출")
+    @DisplayName("[view] [GET] 게시글 페이지 - 정상 호출")
     @Test
     public void requestArticleView() throws Exception {
         // Given

--- a/src/test/java/com/spring/projectboard/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/spring/projectboard/service/ArticleCommentServiceTest.java
@@ -7,6 +7,7 @@ import com.spring.projectboard.dto.ArticleCommentDto;
 import com.spring.projectboard.dto.UserAccountDto;
 import com.spring.projectboard.repository.ArticleCommentRepository;
 import com.spring.projectboard.repository.ArticleRepository;
+import com.spring.projectboard.repository.UserAccountRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +28,7 @@ class ArticleCommentServiceTest {
     @InjectMocks private ArticleCommentService sut;
     @Mock private ArticleRepository articleRepository;
     @Mock private ArticleCommentRepository articleCommentRepository;
+    @Mock private UserAccountRepository userAccountRepository;
 
     @DisplayName("게시글 ID로 댓글 조회")
     @Test
@@ -52,11 +54,13 @@ class ArticleCommentServiceTest {
         ArticleCommentDto dto = createCommentDto("content");
         given(articleRepository.getReferenceById(dto.articleId())).willReturn(createArticle());
         given(articleCommentRepository.save(any(ArticleComment.class))).willReturn(createComment("content"));
+        given(userAccountRepository.getReferenceById(dto.userAccountDto().userId())).willReturn(createUserAccount());
         // When
         sut.saveComment(dto);
         // Then
         then(articleRepository).should().getReferenceById(dto.articleId());
         then(articleCommentRepository).should().save(any(ArticleComment.class));
+        then(userAccountRepository).should().getReferenceById(dto.userAccountDto().userId());
     }
 
     @DisplayName("[예외] 존재하지 않는 게시글에 댓글 저장")
@@ -70,6 +74,7 @@ class ArticleCommentServiceTest {
         // Then
         then(articleRepository).should().getReferenceById(dto.articleId());
         then(articleCommentRepository).shouldHaveNoInteractions();
+        then(userAccountRepository).shouldHaveNoInteractions();
     }
 
     @DisplayName("댓글 수정")


### PR DESCRIPTION
- 게시글 페이지에서 댓글을 등록하기
- 게시글 페이지에서 댓글을 골라 삭제하기
- 테스트

---

-  컨트롤러 & 서비스 코드 작성
- `UserAccountDto`에도 다른 DTO와 마찬가지로 메타정보를 받지 않는 팩토리 메소드를 추가하고 엔티티로 변환할때 `UserAccount` 엔티티를 받도록 수정
- 댓글 저장, 삭제 뷰 구현
