### PR TITLE
인증 기능 구현

### DIFF
--- a/src/main/java/com/spring/projectboard/config/JpaConfig.java
+++ b/src/main/java/com/spring/projectboard/config/JpaConfig.java
@@ -1,9 +1,13 @@
 package com.spring.projectboard.config;
 
+import com.spring.projectboard.dto.security.BoardPrincipal;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import java.util.Optional;
 
@@ -12,6 +16,11 @@ import java.util.Optional;
 public class JpaConfig {
     @Bean
     public AuditorAware<String> auditorAware() {
-        return () -> Optional.of("joo"); //TODO: 스프링 시큐리티로 인증 기능을 붙이게 될 때 수정
+        return () -> Optional.ofNullable(SecurityContextHolder.getContext())
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .map(BoardPrincipal.class::cast)
+                .map(BoardPrincipal::username);
     }
 }

--- a/src/main/java/com/spring/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/spring/projectboard/config/SecurityConfig.java
@@ -1,8 +1,17 @@
 package com.spring.projectboard.config;
 
+import com.spring.projectboard.dto.UserAccountDto;
+import com.spring.projectboard.dto.security.BoardPrincipal;
+import com.spring.projectboard.repository.UserAccountRepository;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -10,8 +19,35 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-                .authorizeRequests(auth -> auth.anyRequest().permitAll())
-                .formLogin().and()
+                .authorizeRequests(auth -> auth
+                        .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers(
+                                HttpMethod.GET,
+                                "/",
+                                "/articles",
+                                "/articles/search-hashtag"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin()
+                        .and()
+                .logout()
+                        .logoutSuccessUrl("/")
+                        .and()
                 .build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(UserAccountRepository userAccountRepository) {
+        return username -> userAccountRepository
+                .findById(username)
+                .map(UserAccountDto::from)
+                .map(BoardPrincipal::from)
+                .orElseThrow(() -> new UsernameNotFoundException("유저를 찾을 수 없습니다. - username: " + username));
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
     }
 }

--- a/src/main/java/com/spring/projectboard/controller/ArticleCommentController.java
+++ b/src/main/java/com/spring/projectboard/controller/ArticleCommentController.java
@@ -1,10 +1,10 @@
 package com.spring.projectboard.controller;
 
-import com.spring.projectboard.dto.UserAccountDto;
+import com.spring.projectboard.dto.security.BoardPrincipal;
 import com.spring.projectboard.request.ArticleCommentRequest;
-import com.spring.projectboard.request.ArticleRequest;
 import com.spring.projectboard.service.ArticleCommentService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -17,15 +17,19 @@ public class ArticleCommentController {
     private final ArticleCommentService articleCommentService;
 
     @PostMapping("/new")
-    public String postNewComment(ArticleCommentRequest articleCommentRequest) {
-        // TODO: 인증 정보 추가
-        articleCommentService.saveComment(articleCommentRequest.toDto(UserAccountDto.of("joo", "pw", "joo@gamil.com", "joo", "memo")));
+    public String postNewComment(
+            ArticleCommentRequest articleCommentRequest,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleCommentService.saveComment(articleCommentRequest.toDto(boardPrincipal.toDto()));
         return "redirect:/articles/" + articleCommentRequest.articleId();
     }
 
     @PostMapping("{commentId}/delete")
-    public String deleteComment(@PathVariable Long commentId, Long articleId) {
-        articleCommentService.deleteComment(commentId);
+    public String deleteComment(
+            @PathVariable Long commentId,
+            Long articleId,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleCommentService.deleteComment(commentId, boardPrincipal.getUsername());
         return "redirect:/articles/" + articleId;
     }
 }

--- a/src/main/java/com/spring/projectboard/controller/ArticleController.java
+++ b/src/main/java/com/spring/projectboard/controller/ArticleController.java
@@ -1,24 +1,21 @@
 package com.spring.projectboard.controller;
 
-import com.spring.projectboard.domain.Article;
 import com.spring.projectboard.domain.constant.FormStatus;
 import com.spring.projectboard.domain.constant.SearchType;
-import com.spring.projectboard.dto.ArticleWithCommentsDto;
-import com.spring.projectboard.dto.UserAccountDto;
 import com.spring.projectboard.dto.response.ArticleResponse;
 import com.spring.projectboard.dto.response.ArticleWithCommentResponse;
+import com.spring.projectboard.dto.security.BoardPrincipal;
 import com.spring.projectboard.request.ArticleRequest;
 import com.spring.projectboard.service.ArticleService;
 import com.spring.projectboard.service.PaginationService;
-import io.micrometer.core.instrument.search.Search;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -87,16 +84,12 @@ public class ArticleController {
     }
 
     @PostMapping("/form")
-    public String postNewArticle(ArticleRequest articleRequest) {
-        //TODO: 인증 정보 추가
+    public String postNewArticle(
+            ArticleRequest articleRequest,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
         articleService.saveArticle(
                 articleRequest.toDto(
-                        UserAccountDto.of(
-                                "joo",
-                                "pw",
-                                "joo@gmail.com",
-                                "Joo",
-                                "memo")
+                        boardPrincipal.toDto()
                 )
         );
         return "redirect:/articles";
@@ -113,26 +106,24 @@ public class ArticleController {
     }
 
     @PostMapping("/{articleId}/form")
-    public String postUpdateArticle(@PathVariable Long articleId, ArticleRequest articleRequest) {
-        //TODO: 인증 정보 추가
+    public String postUpdateArticle(
+            @PathVariable Long articleId,
+            ArticleRequest articleRequest,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
         articleService.updateArticle(
                 articleId,
                 articleRequest.toDto(
-                        UserAccountDto.of(
-                                "joo",
-                                "pw",
-                                "joo@gmail.com",
-                                "Joo",
-                                "memo")
+                        boardPrincipal.toDto()
                 )
         );
         return "redirect:/articles/" + articleId;
     }
 
     @PostMapping("{articleId}/delete")
-    public String deleteArticle(@PathVariable Long articleId) {
-        //TODO: 인증 정보 추가
-        articleService.deleteArticle(articleId);
+    public String deleteArticle(
+            @PathVariable Long articleId,
+            @AuthenticationPrincipal BoardPrincipal boardPrincipal) {
+        articleService.deleteArticle(articleId, boardPrincipal.getUsername());
         return "redirect:/articles";
     }
 }

--- a/src/main/java/com/spring/projectboard/dto/response/ArticleCommentResponse.java
+++ b/src/main/java/com/spring/projectboard/dto/response/ArticleCommentResponse.java
@@ -9,10 +9,11 @@ public record ArticleCommentResponse(
         String content,
         LocalDateTime createdAt,
         String email,
-        String nickname
+        String nickname,
+        String userId
 ) {
-    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname) {
-        return new ArticleCommentResponse(id, content, createdAt, email, nickname);
+    public static ArticleCommentResponse of(Long id, String content, LocalDateTime createdAt, String email, String nickname, String userId) {
+        return new ArticleCommentResponse(id, content, createdAt, email, nickname, userId);
     }
 
     public static ArticleCommentResponse from(ArticleCommentDto dto) {
@@ -25,7 +26,8 @@ public record ArticleCommentResponse(
                 dto.content(),
                 dto.createdAt(),
                 dto.userAccountDto().email(),
-                nickname
+                nickname,
+                dto.userAccountDto().userId()
         );
     }
 }

--- a/src/main/java/com/spring/projectboard/dto/response/ArticleWithCommentResponse.java
+++ b/src/main/java/com/spring/projectboard/dto/response/ArticleWithCommentResponse.java
@@ -15,10 +15,11 @@ public record ArticleWithCommentResponse(
         LocalDateTime createdAt,
         String email,
         String nickname,
+        String userId,
         Set<ArticleCommentResponse> articleCommentResponses
 ) {
-    public static ArticleWithCommentResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, Set<ArticleCommentResponse> articleCommentResponses) {
-        return new ArticleWithCommentResponse(id, title, content, hashtag, createdAt, email, nickname, articleCommentResponses);
+    public static ArticleWithCommentResponse of(Long id, String title, String content, String hashtag, LocalDateTime createdAt, String email, String nickname, String userId, Set<ArticleCommentResponse> articleCommentResponses) {
+        return new ArticleWithCommentResponse(id, title, content, hashtag, createdAt, email, nickname, userId, articleCommentResponses);
     }
 
     public static ArticleWithCommentResponse from(ArticleWithCommentsDto dto) {
@@ -34,6 +35,7 @@ public record ArticleWithCommentResponse(
                 dto.createdAt(),
                 dto.userAccountDto().email(),
                 nickname,
+                dto.userAccountDto().userId(),
                 dto.articleCommentDtos().stream().map(ArticleCommentResponse::from).collect(Collectors.toCollection(LinkedHashSet::new))
         );
     }

--- a/src/main/java/com/spring/projectboard/dto/security/BoardPrincipal.java
+++ b/src/main/java/com/spring/projectboard/dto/security/BoardPrincipal.java
@@ -1,0 +1,93 @@
+package com.spring.projectboard.dto.security;
+
+import com.spring.projectboard.dto.UserAccountDto;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record BoardPrincipal(
+        String username,
+        String password,
+        Collection<? extends GrantedAuthority> authorities,
+        String email,
+        String nickname,
+        String memo
+) implements UserDetails {
+    public static BoardPrincipal of(String username, String password, String email, String nickname, String memo) {
+        Set<RoleType> roleTypes = Set.of(RoleType.USER);
+        return new BoardPrincipal(
+                username,
+                password,
+                roleTypes.stream().map(RoleType::getName).map(SimpleGrantedAuthority::new).collect(Collectors.toUnmodifiableSet()),
+                email,
+                nickname,
+                memo
+        );
+    }
+
+    public static BoardPrincipal from(UserAccountDto dto) {
+        return BoardPrincipal.of(
+                dto.userId(),
+                dto.userPassword(),
+                dto.email(),
+                dto.nickname(),
+                dto.memo()
+        );
+    }
+
+    public UserAccountDto toDto() {
+        return UserAccountDto.of(
+              username,
+              password,
+              email,
+              nickname,
+              memo
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+    @Override
+    public String getPassword() {
+        return password;
+    }
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Getter
+    public enum RoleType {
+        USER("ROLE_USER");
+
+        private final String name;
+
+        RoleType(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/src/main/java/com/spring/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/spring/projectboard/repository/ArticleCommentRepository.java
@@ -28,4 +28,5 @@ public interface ArticleCommentRepository extends
     }
 
     List<ArticleComment> findByArticleId(Long articleId);
+    void deleteByIdAndUserAccount_UserId(Long articleCommentId, String userId);
 }

--- a/src/main/java/com/spring/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/spring/projectboard/repository/ArticleRepository.java
@@ -41,4 +41,6 @@ public interface ArticleRepository extends
     Page<Article> findByUserAccount_NicknameContaining(String searchKeyword, Pageable pageable);
 
     Page<Article> findByHashtag(String s, Pageable pageable);
+
+    void deleteByIdAndUserAccount_UserId(Long articleId, String userId);
 }

--- a/src/main/java/com/spring/projectboard/service/ArticleCommentService.java
+++ b/src/main/java/com/spring/projectboard/service/ArticleCommentService.java
@@ -53,7 +53,7 @@ public class ArticleCommentService {
         }
     }
 
-    public void deleteComment(Long commentId) {
-        articleCommentRepository.deleteById(commentId);
+    public void deleteComment(Long commentId, String userId) {
+        articleCommentRepository.deleteByIdAndUserAccount_UserId(commentId, userId);
     }
 }

--- a/src/main/java/com/spring/projectboard/service/ArticleService.java
+++ b/src/main/java/com/spring/projectboard/service/ArticleService.java
@@ -57,20 +57,25 @@ public class ArticleService {
     public void updateArticle(Long articleId, ArticleDto articleDto) {
         try {
             Article article = articleRepository.getReferenceById(articleId);
-            if (articleDto.title() != null) {
-                article.setTitle(articleDto.title());
+            UserAccount userAccount = userAccountRepository.getReferenceById(articleDto.userAccountDto().userId());
+
+            //작성자와 수정자가 같은지 확인
+            if (article.getUserAccount().equals(userAccount)) {
+                if (articleDto.title() != null) {
+                    article.setTitle(articleDto.title());
+                }
+                if (articleDto.content() != null) {
+                    article.setContent(articleDto.content());
+                }
+                article.setHashtag(articleDto.hashtag());
             }
-            if (articleDto.content() != null) {
-                article.setContent(articleDto.content());
-            }
-            article.setHashtag(articleDto.hashtag());
         } catch (EntityNotFoundException e) {
-            log.warn("게시글 업데이트 실패! 게시글을 찾을 수 없습니다 - ArticleDTO: {}", articleDto);
+            log.warn("게시글 업데이트 실패! 게시글을 수정하는데 필요한 정보를 찾을 수 없습니다 - {}", e);
         }
     }
 
-    public void deleteArticle(Long articleId) {
-        articleRepository.deleteById(articleId);
+    public void deleteArticle(Long articleId, String userId) {
+        articleRepository.deleteByIdAndUserAccount_UserId(articleId, userId);
     }
 
     public long getArticleCount() {

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 --- 테스트 계정
-insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values ('joo', '1234asdf', 'Joo', 'jk042386@gmail.com', 'bulabula', now(), 'joo', now(), 'joo');
-insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values ('a', '1234asdf', 'A', 'a@gmail.com', 'bulabula', now(), 'a', now(), 'a');
+insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values ('joo', '{noop}1234asdf', 'Joo', 'jk042386@gmail.com', 'bulabula', now(), 'joo', now(), 'joo');
+insert into user_account (user_id, user_password, nickname, email, memo, created_at, created_by, modified_at, modified_by) values ('a', '{noop}1234asdf', 'A', 'a@gmail.com', 'bulabula', now(), 'a', now(), 'a');
 
 --- 게시글 123개
 insert into article (user_id, title, content, hashtag, created_by, modified_by, created_at, modified_at) values

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -68,20 +68,25 @@
                     Lorem ipsum dolor sit amet
                   </p>
                 </div>
-                <div class="col-2 mb-3">
+                <div class="col-2 mb-3" align-self-center>
                   <button type="submit" class="btn btn-outline-danger" id="delete-comment-button">삭제</button>
                 </div>
               </div>
             </form>
           </li>
           <li>
-            <div>
-              <strong>Anonymous2</strong>
-              <small><time>2022-01-01</time></small>
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
-                Lorem ipsum dolor sit amet
-              </p>
+            <div class="row">
+              <div class="col-md-10 col-lg-9">
+                <strong>Anonymous2</strong>
+                <small><time>2022-01-01</time></small>
+                <p>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.<br>
+                  Lorem ipsum dolor sit amet
+                </p>
+              </div>
+              <div class="col-2 mb-3">
+                <button type="submit" class="btn btn-outline-danger" hidden>삭제</button>
+              </div>
             </div>
           </li>
         </ul>

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -12,7 +12,7 @@
         <attr sel="#hashtag" th:text="*{hashtag}" />
         <attr sel="#article-content/pre" th:text="*{content}" />
         <!--수정,삭제-->
-        <attr sel="#article-buttons">
+        <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
             <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
                 <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'" />
             </attr>
@@ -28,6 +28,7 @@
                     <attr sel="div/strong" th:text="${articleComment.nickname}" />
                     <attr sel="div/small/time" th:datetime="${articleComment.createdAt}" th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}" />
                     <attr sel="div/p" th:text="${articleComment.content}" />
+                    <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
                 </attr>
             </attr>
         </attr>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -41,7 +41,9 @@
                 </attr>
             </attr>
         </attr>
-        <attr sel="#write-article" th:href="@{/articles/form}" />
+
+        <attr sel="#write-article" sec:authorize="isAuthenticated()" th:href="@{/articles/form}" />
+        
         <attr sel="#pagination">
             <attr sel="li[0]/a"
                   th:text="'Previous'"

--- a/src/main/resources/templates/header.html
+++ b/src/main/resources/templates/header.html
@@ -14,8 +14,9 @@
             </ul>
 
             <div class="text-end">
-                <button type="button" class="btn btn-outline-light me-2">Login</button>
-                <button type="button" class="btn btn-warning">Sign-up</button>
+                <span id="username" class="text-white me-2">username</span>
+                <a role="button" id="login" class="btn btn-outline-light me-2">Login</a>
+                <a role="button" id="logout" class="btn btn-outline-light me-2">Logout</a>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/header.th.xml
+++ b/src/main/resources/templates/header.th.xml
@@ -2,4 +2,7 @@
 <thlogic>
     <attr sel="#home" th:href="@{/}" />
     <attr sel="#hashtag" th:href="@{/articles/search-hashtag}" />
+    <attr sel="#username" sec:authorize="isAuthenticated()" sec:authentication="name" />
+    <attr sel="#login" sec:authorize="!isAuthenticated()" th:href="@{/login}" />
+    <attr sel="#logout" sec:authorize="isAuthenticated()" th:href="@{/logout}" />
 </thlogic>

--- a/src/test/java/com/spring/projectboard/config/TestSecurityConfig.java
+++ b/src/test/java/com/spring/projectboard/config/TestSecurityConfig.java
@@ -1,0 +1,32 @@
+package com.spring.projectboard.config;
+
+import com.spring.projectboard.domain.UserAccount;
+import com.spring.projectboard.repository.UserAccountRepository;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.given;
+
+@Import(SecurityConfig.class)
+public class TestSecurityConfig {
+    @MockBean private UserAccountRepository userAccountRepository;
+
+    @BeforeTestMethod
+    public void securitySetUp() {
+        given(userAccountRepository.findById(anyString()))
+                .willReturn(
+                        Optional.of(
+                                UserAccount.of(
+                                        "jooTest",
+                                        "pw",
+                                        "joo@gmail.com",
+                                        "joo-test",
+                                        "test memo")
+                        )
+                );
+    }
+}

--- a/src/test/java/com/spring/projectboard/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/spring/projectboard/controller/ArticleCommentControllerTest.java
@@ -1,6 +1,7 @@
 package com.spring.projectboard.controller;
 
 import com.spring.projectboard.config.SecurityConfig;
+import com.spring.projectboard.config.TestSecurityConfig;
 import com.spring.projectboard.dto.ArticleCommentDto;
 import com.spring.projectboard.dto.ArticleDto;
 import com.spring.projectboard.request.ArticleCommentRequest;
@@ -16,6 +17,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.TestExecutionEvent;
+import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Map;
@@ -29,7 +32,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 컨트롤러 - 댓글")
-@Import({SecurityConfig.class, FormDataEncoder.class})
+@Import({TestSecurityConfig.class, FormDataEncoder.class})
 @WebMvcTest(ArticleCommentController.class)
 class ArticleCommentControllerTest {
     private final MockMvc mvc;
@@ -42,6 +45,7 @@ class ArticleCommentControllerTest {
         this.formDataEncoder = formDataEncoder;
     }
 
+    @WithUserDetails(value = "jooTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[view][POST] 댓글 등록 - 정상 호출")
     @Test
     void saveNewComment() throws Exception {
@@ -62,13 +66,15 @@ class ArticleCommentControllerTest {
         then(articleCommentService).should().saveComment(any(ArticleCommentDto.class));
     }
 
+    @WithUserDetails(value = "jooTest", setupBefore = TestExecutionEvent.TEST_EXECUTION)
     @DisplayName("[view][POST] 댓글 삭제 - 정상 호출")
     @Test
     void deleteComment() throws Exception {
         // Given
         long articleId = 1L;
         long articleCommentId = 1L;
-        willDoNothing().given(articleCommentService).deleteComment(articleCommentId);
+        String userId = "jooTest";
+        willDoNothing().given(articleCommentService).deleteComment(articleCommentId, userId);
         // When & Then
         mvc.perform(
                         post("/comments/" + articleCommentId + "/delete")
@@ -79,6 +85,6 @@ class ArticleCommentControllerTest {
                 .andExpect(status().is3xxRedirection())
                 .andExpect(view().name("redirect:/articles/" + articleId))
                 .andExpect(redirectedUrl("/articles/" + articleId));
-        then(articleCommentService).should().deleteComment(articleCommentId);
+        then(articleCommentService).should().deleteComment(articleCommentId, userId);
     }
 }

--- a/src/test/java/com/spring/projectboard/repository/JpaRepositoryTest.java
+++ b/src/test/java/com/spring/projectboard/repository/JpaRepositoryTest.java
@@ -8,17 +8,22 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
 @ActiveProfiles("testdb")
 @DisplayName("JPA 연결 테스트")
-@Import(JpaConfig.class)
+@Import(JpaRepositoryTest.TestJpaConfig.class)
 @DataJpaTest
 class JpaRepositoryTest {
     private final ArticleRepository articleRepository;
@@ -87,5 +92,14 @@ class JpaRepositoryTest {
         // Then
         assertThat(articleRepository.count()).isEqualTo(previousArticleCount - 1);
         assertThat(articleCommentRepository.count()).isEqualTo(previousArticleCommentCount - deletedCommentsSize);
+    }
+
+    @EnableJpaAuditing
+    @TestConfiguration
+    public static class TestJpaConfig {
+        @Bean
+        public AuditorAware<String> auditorAware() {
+            return () -> Optional.of("joo");
+        }
     }
 }

--- a/src/test/java/com/spring/projectboard/service/ArticleCommentServiceTest.java
+++ b/src/test/java/com/spring/projectboard/service/ArticleCommentServiceTest.java
@@ -108,11 +108,12 @@ class ArticleCommentServiceTest {
     void deleteComment() {
         // Given
         Long comment_id = 1L;
-        willDoNothing().given(articleCommentRepository).deleteById(comment_id);
+        String userId = "joo";
+        willDoNothing().given(articleCommentRepository).deleteByIdAndUserAccount_UserId(comment_id, userId);
         // When
-        sut.deleteComment(comment_id);
+        sut.deleteComment(comment_id, userId);
         // Then
-        then(articleCommentRepository).should().deleteById(comment_id);
+        then(articleCommentRepository).should().deleteByIdAndUserAccount_UserId(comment_id, userId);
     }
 
     private ArticleCommentDto createCommentDto(String content) {

--- a/src/test/java/com/spring/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/spring/projectboard/service/ArticleServiceTest.java
@@ -180,6 +180,7 @@ class ArticleServiceTest {
         Article article = createArticle();
         ArticleDto articleDto = createArticleDto("new title", "new content", "new hashtag");
         given(articleRepository.getReferenceById(articleDto.id())).willReturn(article);
+        given(userAccountRepository.getReferenceById(articleDto.userAccountDto().userId())).willReturn(articleDto.userAccountDto().toEntity());
         // When
         sut.updateArticle(articleDto.id(), articleDto);
         // Then
@@ -188,6 +189,7 @@ class ArticleServiceTest {
                 .hasFieldOrPropertyWithValue("content", articleDto.content())
                 .hasFieldOrPropertyWithValue("hashtag", articleDto.hashtag());
         then(articleRepository).should().getReferenceById(articleDto.id());
+        then(userAccountRepository).should().getReferenceById(articleDto.userAccountDto().userId());
     }
 
     @DisplayName("[예외] 없는 게시글 수정")
@@ -207,11 +209,12 @@ class ArticleServiceTest {
     void deleteArticle() {
         // Given
         Long article_id = 1L;
-        willDoNothing().given(articleRepository).deleteById(article_id);
+        String userId = "joo";
+        willDoNothing().given(articleRepository).deleteByIdAndUserAccount_UserId(article_id, userId);
         // When
-        sut.deleteArticle(article_id);
+        sut.deleteArticle(article_id, userId);
         // Then
-        then(articleRepository).should().deleteById(article_id);
+        then(articleRepository).should().deleteByIdAndUserAccount_UserId(article_id, userId);
     }
 
     @DisplayName("게시글 수 반환")


### PR DESCRIPTION
- 인증 설정
    - 인증이 필요 없는 영역
        - 루트 페이지
        - 게시판
    - 인증이 필요한 영역
        - 게시글 & 댓글
        - 게시글 쓰기, 수정, 삭제
        - 댓글 쓰기, 삭제
- 인증 기능에 필요한 부분 구현
- 테스트

---

- Controller & Service
    - `SecurityConfig`: security 설정 적용, DB에서 인증 정보를 가져오는 빈 등록, password encoder 빈 등록
    - 컨트롤러에서 인증 정보를 받기위한 `BoardPrincipal` 추가
    - 게시글 삭제, 댓글 삭제 시 `userId`도 요구하도록 수정
    - 테스트 코드에서는 인증을 위해 `TestSecurityConfig`를 작성하고 `@WithMockUser`, `@WithUserDetails`를 사용

- `data.sql`
    - 패스워드 prefix에 와 같이 암호화 정보를 넣어주어야 패스워드 인코더가 읽을 수 있음
    - 테스트 용도의 목적으로만 사용되는 을 사용

- `Response`
    - 게시글/댓글의 등록, 수정, 삭제 버튼이 각각 작성자와 로그인한 사용자와 일치해야만 보일 수 있도록  정보에 를 추가

- View
    - `header`: 인증 정보에 따라 로그인/로그아웃 버튼을 노출시키고 로그인시 username도 같이 노출
    - `index`: 인증 정보에 따라 글쓰기 버튼을 노출
    - `detail`: 인증 정보에 따라 게시글의 수정/삭제, 댓글의 삭제 버튼을 노출

Closes: #47 