### PR TITLE
`equals()`, `hashcode()`에서 필드 접근을 getter로 변경

### DIFF
--- a/src/main/java/com/spring/projectboard/domain/Article.java
+++ b/src/main/java/com/spring/projectboard/domain/Article.java
@@ -62,12 +62,12 @@ public class Article extends AuditingFields{
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false;
-        return id != null && Objects.equals(id, article.id);
+        if (!(o instanceof Article that)) return false;
+        return this.getId() != null && Objects.equals(this.getId(), that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/spring/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/spring/projectboard/domain/ArticleComment.java
@@ -50,11 +50,11 @@ public class ArticleComment extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof ArticleComment that)) return false;
-        return id != null && Objects.equals(id, that.id);
+        return this.getId() != null && Objects.equals(this.getId(), that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/src/main/java/com/spring/projectboard/domain/UserAccount.java
+++ b/src/main/java/com/spring/projectboard/domain/UserAccount.java
@@ -57,11 +57,11 @@ public class UserAccount extends AuditingFields{
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof UserAccount that)) return false;
-        return userId != null && Objects.equals(userId, that.userId);
+        return this.getUserId() != null && Objects.equals(this.getUserId(), that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
- lazy loading으로 프록시 객체를 사용할 경우를 고려하여 getter로 변경

Closes: #66 