### PR TITLE
게시글 뷰 버그 수정

### DIFF
--- a/src/main/java/com/spring/projectboard/domain/Article.java
+++ b/src/main/java/com/spring/projectboard/domain/Article.java
@@ -3,6 +3,8 @@ package com.spring.projectboard.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 import java.util.LinkedHashSet;
@@ -16,7 +18,6 @@ import java.util.Set;
         @Index(columnList = "createdAt"),
         @Index(columnList = "createdBy")
 })
-
 @Entity
 public class Article extends AuditingFields{
     @Id

--- a/src/main/java/com/spring/projectboard/service/ArticleService.java
+++ b/src/main/java/com/spring/projectboard/service/ArticleService.java
@@ -11,12 +11,16 @@ import com.spring.projectboard.repository.UserAccountRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.persistence.EntityNotFoundException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -48,9 +52,21 @@ public class ArticleService {
         return articleRepository.findById(articleId).map(ArticleDto::from).orElseThrow(() -> new EntityNotFoundException("게시글이 없습니다 - articleId: " + articleId));
     }
 
+    @Deprecated
     @Transactional(readOnly = true)
-    public ArticleWithCommentsDto getArticleWithComments(Long articleId) {
+    public ArticleWithCommentsDto getArticleWithComments(Long articleId){
         return articleRepository.findById(articleId).map(ArticleWithCommentsDto::from).orElseThrow(() -> new EntityNotFoundException("게시글이 없습니다 - articleId: " + articleId));
+    }
+
+    @Transactional(readOnly = true)
+    public ArticleWithCommentsDto getArticleWithCommentsByPageIndex(Pageable pageable, int articleIndex) {
+        try {
+            List<Article> articles = articleRepository.findAll(pageable).getContent();
+            Article article = articles.get(articleIndex);
+            return ArticleWithCommentsDto.from(article);
+        } catch (EntityNotFoundException e) {
+            throw e;
+        }
     }
 
     /**

--- a/src/main/java/com/spring/projectboard/service/PaginationService.java
+++ b/src/main/java/com/spring/projectboard/service/PaginationService.java
@@ -1,6 +1,10 @@
 package com.spring.projectboard.service;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 import java.util.stream.IntStream;
@@ -17,5 +21,52 @@ public class PaginationService {
 
     public int currentBarLength() {
         return BAR_LENGTH;
+    }
+
+    public String getPreviousUri(int articleIndex, Pageable pageable) {
+        int pageNumber = pageable.getPageNumber();
+        int pageSize = pageable.getPageSize();
+        UriComponents prevUri = UriComponentsBuilder.newInstance().path("#").build();
+
+        if (pageNumber == 0 && articleIndex == 0){
+            return prevUri.toUriString();
+        } else {
+            if (pageNumber > 0 && articleIndex == 0) {
+                articleIndex = pageSize - 1;
+                pageNumber -= 1;
+            } else {
+                articleIndex -= 1;
+            }
+        }
+
+        prevUri = UriComponentsBuilder.newInstance().path("/articles/detail")
+                .queryParam("articleIndex", articleIndex)
+                .queryParam("page", pageNumber)
+                .build();
+        return prevUri.toUriString();
+    }
+
+    public String getNextUri(int articleIndex, Pageable pageable, long articleTotal) {
+        int pageNumber = pageable.getPageNumber();
+        int pageSize = pageable.getPageSize();
+        int lastPage = (int) articleTotal / pageSize;
+        int lastIndex = (int) articleTotal - (lastPage * pageSize) - 1;
+        UriComponents nextUri = UriComponentsBuilder.newInstance().path("#").build();
+        if (pageNumber == lastPage && articleIndex == lastIndex) {
+            return nextUri.toUriString();
+        } else {
+            if (pageNumber < lastPage && articleIndex == pageSize - 1) {
+                nextUri = UriComponentsBuilder.newInstance().path("/articles/detail")
+                        .queryParam("articleIndex", 0)
+                        .queryParam("page", pageNumber + 1)
+                        .build();
+            } else {
+                nextUri = UriComponentsBuilder.newInstance().path("/articles/detail")
+                        .queryParam("articleIndex", articleIndex + 1)
+                        .queryParam("page", pageNumber)
+                        .build();
+            }
+        }
+        return nextUri.toUriString();
     }
 }

--- a/src/main/resources/templates/articles/detail.html
+++ b/src/main/resources/templates/articles/detail.html
@@ -94,7 +94,7 @@
     </div>
 
     <div class="row g-5">
-      <nav aria-label="Page navigation" id="pagination">
+      <nav id="pagination" aria-label="Page navigation">
         <ul class="pagination">
           <li class="page-item">
             <a class="page-link" href="#" aria-label="Previous">

--- a/src/main/resources/templates/articles/detail.th.xml
+++ b/src/main/resources/templates/articles/detail.th.xml
@@ -13,6 +13,7 @@
             <attr sel="a"
                   th:text="'#' + ${hashtag}"
                   th:href="@{/articles(searchTypes=${searchTypeHashtag},searchValue=${hashtag})}"
+            />
         </attr>
         <attr sel="#article-content/pre" th:text="*{content}" />
         <!--수정,삭제-->
@@ -38,14 +39,16 @@
         </attr>
         <!--페이지네이션-->
         <attr sel="#pagination">
-            <attr sel="li[0]/a"
-                  th:href="*{id} - 1 <= 0 ? '#' : |/articles/*{id - 1}|"
-                  th:class="'page-link' + (*{id} - 1 <= 0 ? ' disabled' : '')"
-            />
-            <attr sel="li[1]/a"
-                  th:href="*{id} + 1 > ${totalCount} ? '#' : |/articles/*{id + 1}|"
-                  th:class="'page-link' + (*{id} - 1 > ${totalCount} ? ' disabled' : '')"
-            />
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:href="${prevUri}"
+                      th:class="'page-link' + (${prevUri} == '#' ? ' disabled' : '')"
+                />
+                <attr sel="li[1]/a"
+                      th:href="${nextUri}"
+                      th:class="'page-link' + (${nextUri} == '#' ? ' disabled' : '')"
+                />
+            </attr>
         </attr>
     </attr>
 </thlogic>

--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -33,9 +33,15 @@
                 />
             </attr>
             <attr sel="tbody" th:remove="all-but-first">
-                <attr sel="tr[0]" th:each="article : ${articles}">
-                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
-                    <attr sel="td.hashtag/span" th:eash="hashtag : ${article.hashtags}">
+                <attr sel="tr[0]" th:each="article, articleStat : ${articles}">
+                    <attr sel="td.title/a"
+                          th:text="${article.title}"
+                          th:href="@{'/articles/detail'
+                              (articleIndex=${articleStat.index},
+                              page=${articles.number},
+                              sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''))}"
+                    />
+                    <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtags}">
                         <attr sel="a"
                               th:text="'#' + ${hashtag}"
                               th:href="@{/articles(searchTypes=${searchTypeHashtag},searchValue=${hashtag})}"
@@ -69,6 +75,4 @@
             />
         </attr>
     </attr>
-
-
 </thlogic>

--- a/src/test/java/com/spring/projectboard/service/ArticleServiceTest.java
+++ b/src/test/java/com/spring/projectboard/service/ArticleServiceTest.java
@@ -18,9 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.*;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.persistence.EntityNotFoundException;
@@ -132,6 +130,31 @@ class ArticleServiceTest {
                 );
 
         then(articleRepository).should().findById(articleId);
+    }
+
+    @DisplayName("Page와 Index로 댓글 달린 게시글 조회")
+    @Test
+    void findArticleWithCommentsByPageIndex() {
+        // Given
+        int articleIndex = 0;
+        int pageNumber = 0;
+        int pageSize = 10;
+        String sortName = "createdAt";
+        Pageable pageable = PageRequest.of(pageNumber, pageSize, Sort.by(Sort.Direction.DESC, sortName));
+        Article article = createArticle();
+        given(articleRepository.findAll(pageable)).willReturn(new PageImpl(List.of(article), pageable, 1));
+        // When
+        ArticleWithCommentsDto dto = sut.getArticleWithCommentsByPageIndex(pageable, articleIndex);
+        // Then
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("title", article.getTitle())
+                .hasFieldOrPropertyWithValue("content", article.getContent())
+                .hasFieldOrPropertyWithValue("hashtagDtos", article.getHashtags().stream()
+                        .map(HashtagDto::from)
+                        .collect(Collectors.toUnmodifiableSet())
+                );
+
+        then(articleRepository).should().findAll(pageable);
     }
 
     @DisplayName("[예외] ID로 존재하지 않는 댓글 달린 게시글 조회")

--- a/src/test/java/com/spring/projectboard/service/PaginationServiceTest.java
+++ b/src/test/java/com/spring/projectboard/service/PaginationServiceTest.java
@@ -7,6 +7,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -59,5 +62,50 @@ class PaginationServiceTest {
         // Then
         assertThat(barLength).isEqualTo(5);
 
+    }
+
+    @DisplayName("이전 게시글 URI 반환")
+    @MethodSource
+    @ParameterizedTest
+    void getPreviousUri(int articleIndex, int pageNumber, String expectedUri) {
+        // Given
+        int pageSize = 10;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        // When
+        String actualUri = sut.getPreviousUri(articleIndex, pageable);
+        // Then
+        assertThat(actualUri).isEqualTo(expectedUri);
+    }
+
+    static Stream<Arguments> getPreviousUri() {
+        return Stream.of(
+                arguments(0, 0, "#"),
+                arguments(4, 0, "/articles/detail?articleIndex=3&page=0"),
+                arguments(0, 1, "/articles/detail?articleIndex=9&page=0"),
+                arguments(3, 1, "/articles/detail?articleIndex=2&page=1")
+        );
+    }
+
+    @DisplayName("다음 게시글 URI 반환")
+    @MethodSource
+    @ParameterizedTest
+    void getNextUri(int articleIndex, int pageNumber, String expectedUri) {
+        // Given
+        int pageSize = 10;
+        long articleTotal = 23;
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+        // When
+        String actualUri = sut.getNextUri(articleIndex, pageable, articleTotal);
+        // Then
+        assertThat(actualUri).isEqualTo(expectedUri);
+    }
+
+    static Stream<Arguments> getNextUri() {
+        return Stream.of(
+                arguments(0, 0, "/articles/detail?articleIndex=1&page=0"),
+                arguments(2, 2, "#"),
+                arguments(9, 1, "/articles/detail?articleIndex=0&page=2"),
+                arguments(3, 1, "/articles/detail?articleIndex=4&page=1")
+        );
     }
 }


### PR DESCRIPTION
- index.th.xml 오타 수정
- detail 렌더링 문제 해결
- page 번호와 page 안의 article index로 게시글을 가져오는 것으로 수정
    - `PaginationService`에 현재 게시글의 이전 게시글 링크와 다음 게시글 링크를 반환하는 메소드를 추가
    - `게시글 id + 1`을 redirection하는 방식은 중간에 삭제된 게시글이 많아질 경우 성능 저하가 발생
- 테스트
    - `PaginationService`
    - `ArticleService`
    - `ArticleController`

Closes: #73 