### PR TITLE
대댓글 도메인 설계: 대댓글 도메인 표현

### DIFF
--- a/src/main/java/com/spring/projectboard/domain/ArticleComment.java
+++ b/src/main/java/com/spring/projectboard/domain/ArticleComment.java
@@ -3,9 +3,12 @@ package com.spring.projectboard.domain;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.core.annotation.Order;
 
 import javax.persistence.*;
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @ToString(callSuper = true)
@@ -22,28 +25,43 @@ public class ArticleComment extends AuditingFields{
 
     @Setter
     @ManyToOne(optional = false)
-    @JoinColumn(name = "userId")
-    UserAccount userAccount;
-
-    @Setter
-    @ManyToOne(optional = false)
     Article article; //게시글 (ID)
 
     @Setter
     @Column(nullable = false, length = 500)
     private String content; //본문
 
+    @Setter
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "userId")
+    UserAccount userAccount;
+
+    @Setter
+    @Column(updatable = false)
+    private Long parentCommentId;
+
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId", cascade = CascadeType.ALL)
+    private Set<ArticleComment> childComments = new LinkedHashSet<>();
+
     protected ArticleComment() {
     }
 
-    private ArticleComment(UserAccount userAccount, Article article, String content) {
+    private ArticleComment(UserAccount userAccount, Article article, String content, Long parentCommentId) {
         this.userAccount = userAccount;
         this.article = article;
         this.content = content;
+        this.parentCommentId = parentCommentId;
     }
 
     public static ArticleComment of(UserAccount userAccount, Article article, String content) {
-        return  new ArticleComment(userAccount, article, content);
+        return  new ArticleComment(userAccount, article, content, null);
+    }
+
+    public void addChildComment(ArticleComment child) {
+        child.setParentCommentId(this.getId());
+        this.getChildComments().add(child);
     }
 
     @Override


### PR DESCRIPTION
- 댓글 도메인 안에서 부모, 자식 관계를 설정하는 코드 추가
- 자식 댓글의 컬렉션 변화가 쿼리에  반영될 수 있도록 cascading 규칙 모두 적용
- 부모 댓글의 id를 직접 지정하여 단방향 연관관계 설정
- 자식 댓글을 추가하는 메소드 추가 

Closes: #76