### PR TITLE
정렬 후 페이지 변경 시 버그 발생

### DIFF
--- a/src/main/resources/templates/articles/index.th.xml
+++ b/src/main/resources/templates/articles/index.th.xml
@@ -59,20 +59,20 @@
         <attr sel="#pagination">
             <attr sel="li[0]/a"
                   th:text="'Previous'"
-                  th:href="@{/articles(page=${articles.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
-                  th:class="'page-link' + (${articles.number} <= 0 ? ' disalbes' : '')"
+                  th:href="@{/articles(page=${articles.number - 1}, sort=*{sort.iterator().next().getProperty()} + ',' + *{sort.iterator().next().getDirection()}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+                  th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
             />
             <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
                 <attr sel="a"
                       th:text="${pageNumber + 1}"
-                      th:href="@{/articles(page=${pageNumber}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
+                      th:href="@{/articles(page=${pageNumber}, sort=*{sort.iterator().next().getProperty()} + ',' + *{sort.iterator().next().getDirection()}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                       th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
                 />
             </attr>
             <attr sel="li[2]/a"
                   th:text="'Next'"
-                  th:href="@{/articles(page=${articles.number + 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
-                  th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disalbes' : '')"
+                  th:href="@{/articles(page=${articles.number + 1}, sort=*{sort.iterator().next().getProperty()} + ',' + *{sort.iterator().next().getDirection()}, searchValue=${param.searchValue})}"
+                  th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
             />
         </attr>
     </attr>


### PR DESCRIPTION
- 정렬 후 페이지 변경 시 발생하는 정렬 사라짐 문제는 페이지네이션에 sort를 지정하지 않아서 발생함 
- 현재 Sort의 정보를 유지하도록 페이지네이션에 sort를 추가
    - Sort의 property는 항상 1개를 가지므로 단순히 `sort.iterator().next()`로 가져오도록함
- 오타 수정

Closes: #81