### PR TITLE
환경변수 치환 후 발생한 테스트 실패 수정

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,3 +49,9 @@ spring:
             # https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+
+---
+
+spring:
+  config.activate.on-profile: test
+  datasource.url: jdbc:h2:mem:testdb

--- a/src/test/java/com/spring/projectboard/ProjectBoardApplicationTests.java
+++ b/src/test/java/com/spring/projectboard/ProjectBoardApplicationTests.java
@@ -2,7 +2,9 @@ package com.spring.projectboard;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ProjectBoardApplicationTests {
 


### PR DESCRIPTION
- #89 에 의해서 환경변수로 치환된 `properties`를 `@SpringBootTest`가 읽게되면서 실패함
- 테스트 전용 프로파일 `test`를 지정하여 인메모리 테스트 DB를 지정하여 해결

Closes: #94 