### PR TITLE
Swagger UI로 API 문서화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,9 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
+	implementation 'org.springdoc:springdoc-openapi-data-rest:1.7.0'
+	implementation 'org.springdoc:springdoc-openapi-javadoc:1.7.0'
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
@@ -52,6 +55,7 @@ dependencies {
 	implementation("com.querydsl:querydsl-jpa")
 	implementation('com.querydsl:querydsl-core')
 	implementation('com.querydsl:querydsl-collections')
+	annotationProcessor('com.github.therapi:therapi-runtime-javadoc-scribe:0.15.0')
 	annotationProcessor("com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa")
 	annotationProcessor('jakarta.annotation:jakarta.annotation-api')
 	annotationProcessor('jakarta.persistence:jakarta.persistence-api')

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -49,6 +49,8 @@ spring:
             # https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+springdoc.swagger-ui.path: /swagger-ui
+
 
 ---
 


### PR DESCRIPTION
- Swagger UI 적용
    - Spring Data Rest 로 만든 API를 보기위해 `springdoc-openapi-data-rest` 추가
    - Javadoc 으로 Swagger 에서 API 별로 설명을 추가할 수 있도록 `springdoc-openapi-javadoc` 추가
        - `therapi-runtime-javadoc-scribe` 도 추가
        -  `springdoc-openapi-data-rest`를 제거하고 실행해야 작동

- `StringIndexOutOfBoundsException`을 해결하기위해 `springdoc.swagger-ui:path` 추가

Closes: #98 