### PR TITLE
코드 리팩토링

### DIFF
--- a/src/main/java/com/spring/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/spring/projectboard/config/SecurityConfig.java
@@ -21,8 +21,6 @@ import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.UUID;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 @Slf4j
 @Configuration
 public class SecurityConfig {

--- a/src/main/java/com/spring/projectboard/controller/ArticleCommentController.java
+++ b/src/main/java/com/spring/projectboard/controller/ArticleCommentController.java
@@ -1,6 +1,5 @@
 package com.spring.projectboard.controller;
 
-import com.spring.projectboard.domain.ArticleComment;
 import com.spring.projectboard.dto.security.BoardPrincipal;
 import com.spring.projectboard.request.ArticleCommentRequest;
 import com.spring.projectboard.service.ArticleCommentService;

--- a/src/main/java/com/spring/projectboard/service/ArticleService.java
+++ b/src/main/java/com/spring/projectboard/service/ArticleService.java
@@ -43,37 +43,21 @@ public class ArticleService {
         };
     }
 
-    @Deprecated
-    @Transactional(readOnly = true)
-    public ArticleDto getArticle(Long articleId) {
-        return articleRepository.findById(articleId)
-                .map(ArticleDto::from)
-                .orElseThrow(() -> new EntityNotFoundException("게시글이 없습니다 - articleId: " + articleId));
-    }
-
     @Transactional(readOnly = true)
     public ArticleDto getArticleDtoByPageIndex(int articleIndex, Pageable pageable) {
         try {
             return ArticleDto.from(getArticleByPageIndex(articleIndex, pageable));
-        } catch (EntityNotFoundException e) {
-            throw e;
+        } catch (IndexOutOfBoundsException e) {
+            throw new EntityNotFoundException(e.getMessage());
         }
-    }
-
-    @Deprecated
-    @Transactional(readOnly = true)
-    public ArticleWithCommentsDto getArticleWithCommentsDto(Long articleId){
-        return articleRepository.findById(articleId)
-                .map(ArticleWithCommentsDto::from)
-                .orElseThrow(() -> new EntityNotFoundException("게시글이 없습니다 - articleId: " + articleId));
     }
 
     @Transactional(readOnly = true)
     public ArticleWithCommentsDto getArticleWithCommentsDtoByPageIndex(int articleIndex, Pageable pageable) {
         try {
             return ArticleWithCommentsDto.from(getArticleByPageIndex(articleIndex, pageable));
-        } catch (EntityNotFoundException e) {
-            throw e;
+        } catch (IndexOutOfBoundsException e) {
+            throw new EntityNotFoundException(e.getMessage());
         }
     }
 

--- a/src/main/resources/templates/articles/search-hashtag.html
+++ b/src/main/resources/templates/articles/search-hashtag.html
@@ -10,7 +10,6 @@
     <link href="/css/articles/table-header.css" rel="stylesheet">
 </head>
 <body>
-- 게시글 해시태그 검색
     <header id="header">
         헤더 삽입부
         <hr>

--- a/src/test/java/com/spring/projectboard/controller/ArticleCommentControllerTest.java
+++ b/src/test/java/com/spring/projectboard/controller/ArticleCommentControllerTest.java
@@ -1,9 +1,6 @@
 package com.spring.projectboard.controller;
 
 import com.spring.projectboard.config.TestSecurityConfig;
-import com.spring.projectboard.domain.Article;
-import com.spring.projectboard.domain.ArticleComment;
-import com.spring.projectboard.domain.UserAccount;
 import com.spring.projectboard.dto.ArticleCommentDto;
 import com.spring.projectboard.request.ArticleCommentRequest;
 import com.spring.projectboard.service.ArticleCommentService;

--- a/src/test/java/com/spring/projectboard/controller/AuthControllerTest.java
+++ b/src/test/java/com/spring/projectboard/controller/AuthControllerTest.java
@@ -15,7 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("View 컨트롤러 - 인증")
 @Import(TestSecurityConfig.class)
-@WebMvcTest(Void.class)
+@WebMvcTest(LoginController.class)
 public class AuthControllerTest {
     private final MockMvc mvc;
 


### PR DESCRIPTION
- `ArticleService`, `ArticleRepositoryCustom` 의 Deprecated 메소드 삭제
- Deprecated 메소드 관련 테스트 수정/삭제
- hashtag 페이지 body 최상단 불필요한 텍스트 삭제
- #105 에 의해서 `AuthControllerTest` 에 `LoginController` 의존성 추가
- Import 정리

Closes: #107 