### PR TITLE
API 호출이 가능하도록 인증 설정 변경

### DIFF
--- a/src/main/java/com/spring/projectboard/config/DataRestconfig.java
+++ b/src/main/java/com/spring/projectboard/config/DataRestconfig.java
@@ -1,5 +1,8 @@
 package com.spring.projectboard.config;
 
+import com.spring.projectboard.domain.Article;
+import com.spring.projectboard.domain.ArticleComment;
+import com.spring.projectboard.domain.Hashtag;
 import com.spring.projectboard.domain.UserAccount;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,6 +12,12 @@ import org.springframework.data.rest.webmvc.config.RepositoryRestConfigurer;
 public class DataRestconfig {
     @Bean
     public RepositoryRestConfigurer repositoryRestConfigurer() {
-        return RepositoryRestConfigurer.withConfig((config, cors) -> config.exposeIdsFor(UserAccount.class));
+        return RepositoryRestConfigurer.withConfig((config, cors) ->
+                config
+                        .exposeIdsFor(UserAccount.class)
+                        .exposeIdsFor(Article.class)
+                        .exposeIdsFor(ArticleComment.class)
+                        .exposeIdsFor(Hashtag.class)
+        );
     }
 }

--- a/src/main/java/com/spring/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/spring/projectboard/config/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
         return http
                 .authorizeRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers("/api/**").permitAll()
                         .mvcMatchers(
                                 HttpMethod.GET,
                                 "/",
@@ -52,6 +53,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(oAuth2UserService))
                 )
+                .csrf(csrf -> csrf.ignoringAntMatchers("/api/**"))
                 .build();
     }
 

--- a/src/main/java/com/spring/projectboard/domain/projection/ArticleCommentProjection.java
+++ b/src/main/java/com/spring/projectboard/domain/projection/ArticleCommentProjection.java
@@ -1,0 +1,21 @@
+package com.spring.projectboard.domain.projection;
+
+import com.spring.projectboard.domain.Article;
+import com.spring.projectboard.domain.ArticleComment;
+import com.spring.projectboard.domain.UserAccount;
+import org.springframework.data.rest.core.config.Projection;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Projection(name = "withUserAccount", types = ArticleComment.class)
+public interface ArticleCommentProjection {
+    Long getId();
+    String getContent();
+    UserAccount getUserAccount();
+    Long getParentCommentId();
+    LocalDateTime getCreatedAt();
+    String getCreatedBy();
+    LocalDateTime getModifiedAt();
+    String getModifiedBy();
+}

--- a/src/main/java/com/spring/projectboard/domain/projection/ArticleProjection.java
+++ b/src/main/java/com/spring/projectboard/domain/projection/ArticleProjection.java
@@ -1,0 +1,19 @@
+package com.spring.projectboard.domain.projection;
+
+import com.spring.projectboard.domain.Article;
+import com.spring.projectboard.domain.UserAccount;
+import org.springframework.data.rest.core.config.Projection;
+
+import java.time.LocalDateTime;
+
+@Projection(name = "withUserAccount", types = Article.class)
+public interface ArticleProjection {
+    Long getId();
+    UserAccount getUserAccount();
+    String getTitle();
+    String getContent();
+    LocalDateTime getCreatedAt();
+    String getCreatedBy();
+    LocalDateTime getModifiedAt();
+    String getModifiedBy();
+}

--- a/src/main/java/com/spring/projectboard/domain/projection/UserAccountProjection.java
+++ b/src/main/java/com/spring/projectboard/domain/projection/UserAccountProjection.java
@@ -1,0 +1,18 @@
+package com.spring.projectboard.domain.projection;
+
+import com.spring.projectboard.domain.UserAccount;
+import org.springframework.data.rest.core.config.Projection;
+
+import java.time.LocalDateTime;
+
+@Projection(name = "withoutPassword", types = UserAccount.class)
+public interface UserAccountProjection {
+    String getUserId();
+    String getEmail();
+    String getNickname();
+    String getMemo();
+    LocalDateTime getCreatedAt();
+    String getCreatedBy();
+    LocalDateTime getModifiedAt();
+    String getModifiedBy();
+}

--- a/src/main/java/com/spring/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/spring/projectboard/repository/ArticleCommentRepository.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.spring.projectboard.domain.ArticleComment;
 import com.spring.projectboard.domain.QArticleComment;
+import com.spring.projectboard.domain.projection.ArticleCommentProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.querydsl.QuerydslPredicateExecutor;
 import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
@@ -12,7 +13,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import java.util.List;
 
-@RepositoryRestResource
+@RepositoryRestResource(excerptProjection = ArticleCommentProjection.class)
 public interface ArticleCommentRepository extends
         JpaRepository<ArticleComment, Long>,
         QuerydslPredicateExecutor<ArticleComment>,

--- a/src/main/java/com/spring/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/spring/projectboard/repository/ArticleRepository.java
@@ -4,6 +4,8 @@ import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.spring.projectboard.domain.Article;
 import com.spring.projectboard.domain.QArticle;
+import com.spring.projectboard.domain.projection.ArticleCommentProjection;
+import com.spring.projectboard.domain.projection.ArticleProjection;
 import com.spring.projectboard.repository.querydsl.ArticleRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +15,7 @@ import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@RepositoryRestResource
+@RepositoryRestResource(excerptProjection = ArticleProjection.class)
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
         ArticleRepositoryCustom,

--- a/src/main/java/com/spring/projectboard/repository/UserAccountRepository.java
+++ b/src/main/java/com/spring/projectboard/repository/UserAccountRepository.java
@@ -1,7 +1,11 @@
 package com.spring.projectboard.repository;
 
 import com.spring.projectboard.domain.UserAccount;
+import com.spring.projectboard.domain.projection.ArticleProjection;
+import com.spring.projectboard.domain.projection.UserAccountProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource(excerptProjection = UserAccountProjection.class)
 public interface UserAccountRepository extends JpaRepository<UserAccount, String>{
 }

--- a/src/main/java/com/spring/projectboard/repository/querydsl/ArticleRepositoryCustom.java
+++ b/src/main/java/com/spring/projectboard/repository/querydsl/ArticleRepositoryCustom.java
@@ -8,11 +8,5 @@ import java.util.Collection;
 import java.util.List;
 
 public interface ArticleRepositoryCustom {
-    /**
-     * @deprecated 해시태그 도메인을 새로 만들었으므로 사용할 필요 없다.
-     * @see HashtagRepositoryCustom#findALlHashtagNames()
-     */
-    @Deprecated
-    List<String> findAllDistinctHashtags();
     Page<Article> findByHashtagNames(Collection<String> hashtagNames, Pageable pageable);
 }

--- a/src/main/java/com/spring/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/src/main/java/com/spring/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -18,16 +18,6 @@ public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport imple
     }
 
     @Override
-    public List<String> findAllDistinctHashtags() {
-        QArticle article = QArticle.article;
-
-        return from(article)
-                .distinct()
-                .select(article.hashtags.any().hashtagName)
-                .fetch();
-    }
-
-    @Override
     public Page<Article> findByHashtagNames(Collection<String> hashtagNames, Pageable pageable) {
         QHashtag hashtag = QHashtag.hashtag;
         QArticle article = QArticle.article;


### PR DESCRIPTION
- 어드민 프로젝트에서 사용할 Data REST API 에 ID 필드를 오픈
    - Data REST가 자동 생성하는 API는 ID 값을 노출하지 않는 것이 Default이기 때문에 이를 노출해주도록 설정
    - ID 값은 어드민 프로젝트에서 관리 목적으로 사용할 예정

- Data REST Projection을 사용하여 UserAccount 노출
    - Article, ArticleComment 내의 UserAccount를 href로 나오지 않도록 Projection을 사용하여 노출
    - Article, ArticleComment, UserAccount 에서 노출할 필드들을 직접 지정

- #107 에서 삭제되어야할 `ArticleRepositoryCustom`의 Deprecated 메소드 삭제

Closes: #112 