### PR TITLE
운영 서버에서 data.sql 데이터가 추가되지 않도록 설정

### DIFF
--- a/src/main/resources/application-cloudtype.yaml
+++ b/src/main/resources/application-cloudtype.yaml
@@ -4,7 +4,7 @@ spring:
     username: ${DB_ROOT_USERNAME}
     password: ${DB_ROOT_PASSWORD}
     driver-class-name: org.mariadb.jdbc.Driver
-  sql.init.mode: always
+  sql.init.mode: never
   jpa.hibernate.ddl-auto: none
   security:
     oauth2:


### PR DESCRIPTION
- 운영 서버에서 DB가 data.sql로 초기화되지 않도록 설정
    - `sql.init.mode`를 never로 설정하여 DB가 초기화되지않도록 함
    - 초기 테이블 DDL은 외부에서 따로 진행하는 것으로 결정

Closes: #109